### PR TITLE
fix(install): error import when package dir was not equal to package name

### DIFF
--- a/install/parser/funcs.go
+++ b/install/parser/funcs.go
@@ -49,6 +49,9 @@ func GetDirPackageName(dir string) string {
 }
 
 func generateNotDuplicateAlias(importMap map[string]*Import, name string) string {
+	if _, ok := importMap[name]; !ok {
+		return name
+	}
 	for i := 1; i < 1000; i++ {
 		newName := fmt.Sprintf("%s%d", name, i)
 		if _, ok := importMap[newName]; !ok {


### PR DESCRIPTION

- Add check for existing package name in generateNotDuplicateAlias function
- Update package name and path handling in loader.go
- Modify alias generation logic to handle different package naming scenarios- Refactor pkgNameMap usage to store aliases instead of package names